### PR TITLE
Fix Shape Restoration of `face_mask` After `masked_fill` on `recon_faces`

### DIFF
--- a/meshgpt_pytorch/meshgpt_pytorch.py
+++ b/meshgpt_pytorch/meshgpt_pytorch.py
@@ -996,6 +996,7 @@ class MeshAutoencoder(Module):
             recon_faces = rearrange(recon_faces, 'b nf (nv c) -> b nf nv c', nv = 3)
             face_mask = rearrange(face_mask, 'b nf -> b nf 1 1')
             recon_faces = recon_faces.masked_fill(~face_mask, float('nan'))
+            face_mask = rearrange(face_mask, 'b nf 1 1 -> b nf')
 
         if only_return_recon_faces:
             return recon_faces


### PR DESCRIPTION
#40 
- **Overview:** This commit addresses the issue of restoring the shape of `face_mask` after performing `masked_fill` on `recon_faces`.
- **Background:** An issue was identified where the shape of `face_mask` was not properly restored after applying a mask to the reconstructed facial data (`recon_faces`). This could affect subsequent processes.