### PR TITLE
Flash attention mispelling flash_attn -> attn_flash

### DIFF
--- a/meshgpt_pytorch/meshgpt_pytorch.py
+++ b/meshgpt_pytorch/meshgpt_pytorch.py
@@ -1132,7 +1132,7 @@ class MeshTransformer(Module):
             depth = attn_depth,
             dim_head = attn_dim_head,
             heads = attn_heads,
-            flash_attn = flash_attn,
+            attn_flash = flash_attn,
             attn_dropout = dropout,
             ff_dropout = dropout,
             cross_attend = condition_on_text,
@@ -1155,7 +1155,7 @@ class MeshTransformer(Module):
             depth = fine_attn_depth,
             dim_head = attn_dim_head,
             heads = attn_heads,
-            flash_attn = flash_attn,
+            attn_flash = flash_attn,
             attn_dropout = dropout,
             ff_dropout = dropout,
             **attn_kwargs


### PR DESCRIPTION
Seems like the flash attention was never implemented correctly due to  a misspelling, hopefully this will improve performance .

x-transformers.py -> AttentionLayers:
```
 attn_kwargs, kwargs = groupby_prefix_and_trim('attn_', kwargs)
 flash_attn = attn_kwargs.get('flash', False)
```
